### PR TITLE
Docs: correct file path typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A stamp and art saving mod for for WEBFISHING using GDWeave
 - you might get temporarily kicked for spawning canvases in cove servers (they are considered an illegal actor)
 - In-game canvases have a **200x200** resolution. I recommend **keeping stamps below this size**
 - **Off-canvas**: a maximum of four chalk canvases (200*200) can be placed
-- Saved stamps are located at `/home/user/.local/share/webfishing_stamps_mod` on Linux or `%appdata%/local/webfishing_stamps_mod` on Windows
+- Saved stamps are located at `/home/user/.local/share/webfishing_stamps_mod` on Linux or `%localappdata%/webfishing_stamps_mod` on Windows
 - **DONT** move when placing gifs down
 - Be mindful of **performance and lag**, especially if playing GIFs. This is a **server side mod**, and people play on potatoes
 - I recommend installing the **Calico mod**! (it can cause stuttering with gifs though)


### PR DESCRIPTION
`%appdata%/local/webfishing_stamps_mod` would expand to `C:\Users\User\AppData\Roaming\local` rather than `C:\Users\User\AppData\Local`